### PR TITLE
fix: mybatis-plus查询需要手动加密

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <groupId>com.hlqz</groupId>
   <artifactId>lpg</artifactId>
-  <version>0.1.3-SNAPSHOT</version>
+  <version>0.1.4-SNAPSHOT</version>
   <name>LPG</name>
   <description>LPG Server</description>
   <properties>

--- a/src/main/java/com/hlqz/lpg/mybatis/dao/impl/UserDAOImpl.java
+++ b/src/main/java/com/hlqz/lpg/mybatis/dao/impl/UserDAOImpl.java
@@ -4,6 +4,8 @@ import com.github.yulichang.base.MPJBaseServiceImpl;
 import com.hlqz.lpg.model.entity.User;
 import com.hlqz.lpg.mybatis.dao.UserDAO;
 import com.hlqz.lpg.mybatis.mapper.UserMapper;
+import com.hlqz.lpg.util.AesUtils;
+import com.hlqz.lpg.util.ConfigUtils;
 import org.springframework.stereotype.Service;
 
 /**
@@ -16,7 +18,7 @@ public class UserDAOImpl extends MPJBaseServiceImpl<UserMapper, User> implements
     @Override
     public User fetchByRealNameAndMobile(String realName, String mobile) {
         return lambdaQuery().eq(User::getRealName, realName)
-            .eq(User::getMobile, mobile)
+            .eq(User::getMobile, AesUtils.encrypt(mobile, ConfigUtils.getDatabaseAesKey()))
             .one();
     }
 }


### PR DESCRIPTION
mybatis-plus使用TypeHandler只有insert和update时候会触发，query不会触发TypeHandler，所以查询时候需要手动对字段进行加密